### PR TITLE
[push-flow][l]: allow pushing without datapackage.json

### DIFF
--- a/lib/utils/datahub.js
+++ b/lib/utils/datahub.js
@@ -339,11 +339,18 @@ class DataHub extends EventEmitter {
 function generateDpForFlow(flowSpec, dpJson = {}) {
   let descriptor = lodash.cloneDeep(dpJson)
   let resources = descriptor.resources || []
+
   if (resources.length > 0) {
     return descriptor
   }
   if (lodash.isEmpty(descriptor)) {
     descriptor.name = flowSpec.meta.dataset
+  }
+  const flowDescriptor = flowSpec.inputs[0].parameters.descriptor
+  if (flowDescriptor) {
+    if (!lodash.isEmpty(flowDescriptor)){
+      return flowSpec.inputs[0].parameters.descriptor
+    }
   }
   const resourceMapping = flowSpec.inputs[0].parameters['resource-mapping']
   lodash.forOwn(resourceMapping, (_, resource) => {

--- a/lib/utils/datahub.js
+++ b/lib/utils/datahub.js
@@ -121,16 +121,16 @@ class DataHub extends EventEmitter {
       let content
       try {
         content = fs.readFileSync(dpJsonPath)
+        descriptor = JSON.parse(content)
       } catch (err) {
-        throw new Error(err.message)
+        console.log(`Couldn't load datapackage.json from ${dpJsonPath}. Creating from the scratch...`)
       }
-      descriptor = JSON.parse(content)
     }
 
     try {
       spec = YAML.load(specPath)
     } catch (err) {
-      throw new Error(err.message)
+      throw new Error(`Couldn't read "flow.yaml". Please, check if it's correctly formatted`)
     }
 
     descriptor = generateDpForFlow(spec, descriptor)

--- a/lib/utils/datahub.js
+++ b/lib/utils/datahub.js
@@ -349,7 +349,7 @@ function generateDpForFlow(flowSpec, dpJson = {}) {
   const flowDescriptor = flowSpec.inputs[0].parameters.descriptor
   if (flowDescriptor) {
     if (!lodash.isEmpty(flowDescriptor)){
-      return flowSpec.inputs[0].parameters.descriptor
+      return flowDescriptor
     }
   }
   const resourceMapping = flowSpec.inputs[0].parameters['resource-mapping']

--- a/lib/utils/datahub.js
+++ b/lib/utils/datahub.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events')
 const fetch = require('node-fetch')
 const FormData = require('form-data')
+const fs = require('fs')
 const lodash = require('lodash')
 const {File, xlsxParser} = require('data.js')
 const XLSX = require('xlsx')
@@ -112,30 +113,91 @@ class DataHub extends EventEmitter {
     throw new Error(responseError(res))
   }
 
-  async pushFlow(specPath){
+  async pushFlow(specPath, dpJsonPath = '.datahub/datapackage.json'){
     let spec = {}
     let descriptor = {}
+
+    if (fs.existsSync(dpJsonPath)) {
+      let content
+      try {
+        content = fs.readFileSync(dpJsonPath)
+      } catch (err) {
+        throw new Error(err.message)
+      }
+      descriptor = JSON.parse(content)
+    }
+
     try {
       spec = YAML.load(specPath)
     } catch (err) {
       throw new Error(err.message)
     }
 
+    descriptor = generateDpForFlow(spec, descriptor)
+
+    let resources = []
+    const options = {findability: spec.meta.findability}
+    const dpJsonResource = File.load({
+      path: 'datapackage.json',
+      name: 'datapackage.json',
+      data: descriptor
+    })
+    resources.push(dpJsonResource)
+
+    this._debugMsg('Getting rawstore upload creds')
+
+    const rawstoreUploadCreds = await this.rawstoreAuthorize(resources, options)
+
+    this._debugMsg('Uploading to rawstore with creds ...')
+    this._debugMsg(rawstoreUploadCreds)
+
+    const uploads = resources.map(async resource => {
+      const creds = rawstoreUploadCreds[resource.descriptor.path]
+      const formData = new FormData()
+      lodash.forEach(creds.upload_query, (v, k) => {
+        formData.append(k, v)
+      })
+      formData.append('file', resource.stream(), {
+        knownLength: resource.size,
+        contentType: creds.upload_query['Content-Type']
+      })
+      const totalLength = formData.getLengthSync()
+
+      // Use straight fetch as not interacting with API but with external object store
+      const uploadRes = await fetch(creds.upload_url, {
+        method: 'POST',
+        body: formData,
+        headers: {
+          'Content-Length': totalLength
+        }
+      })
+      if (uploadRes.status > 204) {
+        const body = await uploadRes.text()
+        throw new Error(`Error uploading to rawstore for ${uploadResource.descriptor.path} with code ${uploadRes.status} reason ${body}`)
+      }
+      creds.rawstore_url = creds.upload_url + '/' + creds.upload_query.key
+    })
+    await Promise.all(uploads)
+
+    this._debugMsg('Uploads to rawstore: Complete')
+
+    const token = await this._authz('source')
+    const dpUrl = rawstoreUploadCreds['datapackage.json'].rawstore_url
+    const signedRes = await this._fetch(
+        `/rawstore/presign?ownerid=${this._ownerid}&url=${dpUrl}`,
+        token, {method: 'GET'}
+    )
+    if (signedRes.status !== 200) {
+      throw new Error(responseError(signedRes))
+    }
+    const dpSignedurl = await signedRes.json()
+
+    spec.inputs[0].url = dpSignedurl.url
+    spec.inputs[0].parameters.descriptor = descriptor
+
     this._debugMsg('Calling source upload with spec')
     this._debugMsg(spec)
 
-    // Attach dp.json
-    const dpUrl = spec.inputs[0].url
-    const dpRes =  await fetch(dpUrl)
-    if (dpRes.status === 200) {
-      descriptor = await dpRes.json()
-    } else {
-      throw new Error(responseError(dpRes))
-    }
-    spec.inputs[0].parameters.descriptor = descriptor
-
-
-    const token = await this._authz('source')
     const res = await this._fetch('/source/upload', token, {
       method: 'POST',
       body: spec
@@ -272,6 +334,23 @@ class DataHub extends EventEmitter {
       schedule
     }
   }
+}
+
+function generateDpForFlow(flowSpec, dpJson = {}) {
+  let descriptor = lodash.cloneDeep(dpJson)
+  let resources = descriptor.resources || []
+  if (resources.length > 0) {
+    return descriptor
+  }
+  if (lodash.isEmpty(descriptor)) {
+    descriptor.name = flowSpec.meta.dataset
+  }
+  const resourceMapping = flowSpec.inputs[0].parameters['resource-mapping']
+  lodash.forOwn(resourceMapping, (_, resource) => {
+    resources.push({'name': resource, 'path': `data/${resource}.csv`})
+  })
+  descriptor.resources = resources
+  return descriptor
 }
 
 async function processExcelSheets(resources = [], sheets) {


### PR DESCRIPTION
* get rid of required remote datapackage.json
* pushing datapackage.json into rawstore for users doing one of 3:
  * reading datapackage.json locally if exists and pushing
  * generating dp.json from scratch if not exists
  * adding resources according to flow.yaml if not specified in local datapckage.json
* Tests updated
fixes #10