### PR TITLE
[push][m]: guess resource encoding

### DIFF
--- a/lib/utils/datahub.js
+++ b/lib/utils/datahub.js
@@ -33,12 +33,15 @@ class DataHub extends EventEmitter {
     // Exclude remote Resources
     resources = resources.filter(res => res.descriptor.pathType === 'local')
     // Get Dataset itself (datapackage.json) as an (Inline) File
-    const _descriptor = lodash.cloneDeep(dataset.descriptor)
+    const _descriptor = lodash.cloneDeep(
+      this._guessEncodings(dataset.descriptor, resources)
+    )
     const dpJsonResource = File.load({
       path: 'datapackage.json',
       name: 'datapackage.json',
       data: _descriptor
     })
+
     resources.push(dpJsonResource)
 
     this._debugMsg('Getting rawstore upload creds')
@@ -276,6 +279,23 @@ class DataHub extends EventEmitter {
       }
       console.log('> [debug] ' + msg)
     }
+  }
+
+  _guessEncodings(dpJson, resourceData) {
+    lodash.forEach(resourceData, (resource) => {
+
+      let resToModify = dpJson.resources.find(res => {
+        return res.name === resource.descriptor.name
+      })
+      if (!resToModify.encoding) {
+        const resFile = File.load({
+          path: resource.path || resource.url ,
+          name: resource.name
+        })
+        resToModify.encoding = resFile.encoding
+      }
+    })
+    return dpJson
   }
 
 

--- a/test/fixtures/dp-encodings/datapackage.json
+++ b/test/fixtures/dp-encodings/datapackage.json
@@ -1,0 +1,77 @@
+{
+  "name": "iso",
+  "resources": [
+    {
+      "name": "western-macos-roman",
+      "path": "western-macos-roman.csv",
+      "schema": {
+        "fields": [
+          {
+            "name": "Country Name",
+            "type": "string"
+          },
+          {
+            "name": "Country Code",
+            "type": "string"
+          },
+          {
+            "name": "Year",
+            "type": "integer"
+          },
+          {
+            "name": "Value",
+            "type": "integer"
+          }
+        ]
+      }
+    },
+    {
+      "name": "iso",
+      "path": "iso8859.csv",
+      "schema": {
+        "fields": [
+          {
+            "name": "Country Name",
+            "type": "string"
+          },
+          {
+            "name": "Country Code",
+            "type": "string"
+          },
+          {
+            "name": "Year",
+            "type": "integer"
+          },
+          {
+            "name": "Value",
+            "type": "integer"
+          }
+        ]
+      }
+    },
+    {
+      "name": "utf",
+      "path": "utf8.csv",
+      "schema": {
+        "fields": [
+          {
+            "name": "Country Name",
+            "type": "string"
+          },
+          {
+            "name": "Country Code",
+            "type": "string"
+          },
+          {
+            "name": "Year",
+            "type": "integer"
+          },
+          {
+            "name": "Value",
+            "type": "integer"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/dp-encodings/iso8859.csv
+++ b/test/fixtures/dp-encodings/iso8859.csv
@@ -1,0 +1,6 @@
+Country Name,Country Code,Year,Value
+Réunion,ECS,1989,838462813
+Réunion,ECS,1990,842848473
+Réunion,ECS,1991,846178277
+Réunion,ECS,1992,849656744
+Réunion,ECS,1993,852762014

--- a/test/fixtures/dp-encodings/utf8.csv
+++ b/test/fixtures/dp-encodings/utf8.csv
@@ -1,0 +1,6 @@
+Country Name,Country Code,Year,Value
+Réunion,ECS,1989,838462813
+Réunion,ECS,1990,842848473
+Réunion,ECS,1991,846178277
+Réunion,ECS,1992,849656744
+Réunion,ECS,1993,852762014

--- a/test/fixtures/dp-encodings/western-macos-roman.csv
+++ b/test/fixtures/dp-encodings/western-macos-roman.csv
@@ -1,0 +1,6 @@
+Country Name,Country Code,Year,Value
+RŽunion,ECS,1989,838462813
+RŽunion,ECS,1990,842848473
+RŽunion,ECS,1991,846178277
+RŽunion,ECS,1992,849656744
+RŽunion,ECS,1993,852762014

--- a/test/utils.datahub.test.js
+++ b/test/utils.datahub.test.js
@@ -40,8 +40,8 @@ const finVixInfo = {
     name: 'vix-daily'
   },
   'datapackage.json': {
-    length: 2830,
-    md5: 's6Ex9JHrfrGSkEF7Gin8jg==',
+    length: 2854,
+    md5: 'm0kbjn9IxjopdBZo8bk0AA==',
     name: 'datapackage.json'
   }
 }
@@ -54,12 +54,109 @@ const finVixInfoWithoutResources = {
   }
 }
 
+const encodedInfo = {
+  "western-macos-roman.csv": {
+    "length":171,
+    "md5":"IQKcpyJFVG3AKDZ1XfpsFg==",
+    "name":"western-macos-roman"
+  },
+  "iso8859.csv": {
+    "length":171,
+    "md5":"9YPisX1dNWWwt6OshEm7hg==",
+    "name":"iso"
+  },
+  "utf8.csv": {
+    "length":176,
+    "md5":"VEyDK+05c4GRdRA5cvcKVw==",
+    "name":"utf"
+  },
+  "datapackage.json": {
+    "length":737,
+    "md5":"jT+FS1ETWeNoGP1leT/6dQ==",
+    "name":"datapackage.json"
+  }
+}
+
 const rawstoreUrl = 'https://s3-us-west-2.amazonaws.com'
 
 const flowPushNock = nock('http://testing.com')
   .persist()
   .get('/.datahub/datapackage.json')
   .reply(200, {name: 'name'})
+
+const rawstoreAuthorizeEncoding = nock(config.api, {reqheaders: {'Auth-Token': 'authz.token'}})
+  .persist()
+  .post('/rawstore/authorize', {
+    metadata: {
+      owner: config.profile.id,
+      findability: 'unlisted'
+    },
+    filedata: encodedInfo
+  })
+  .reply(200, {
+    filedata: {
+      'western-macos-roman.csv': {
+        md5: encodedInfo['western-macos-roman.csv'].md5,
+        length: encodedInfo['western-macos-roman.csv'].length,
+        name: encodedInfo['western-macos-roman.csv'].name,
+        // eslint-disable-next-line camelcase
+        upload_query: {
+          key: encodedInfo['western-macos-roman.csv'].md5,
+          policy: '...',
+          'x-amz-algorithm': 'AWS4-HMAC-SHA256',
+          'x-amz-credential': 'XXX',
+          'x-amz-signature': 'YYY'
+        },
+        // eslint-disable-next-line camelcase
+        upload_url: rawstoreUrl
+      },
+      'iso8859.csv': {
+        md5: encodedInfo['iso8859.csv'].md5,
+        length: encodedInfo['iso8859.csv'].length,
+        name: encodedInfo['iso8859.csv'].name,
+        // eslint-disable-next-line camelcase
+        upload_query: {
+          key: encodedInfo['iso8859.csv'].md5,
+          policy: '...',
+          'x-amz-algorithm': 'AWS4-HMAC-SHA256',
+          'x-amz-credential': 'XXX',
+          'x-amz-signature': 'YYY'
+        },
+        // eslint-disable-next-line camelcase
+        upload_url: rawstoreUrl
+      },
+      'utf8.csv': {
+        md5: encodedInfo['utf8.csv'].md5,
+        length: encodedInfo['utf8.csv'].length,
+        name: encodedInfo['utf8.csv'].name,
+        // eslint-disable-next-line camelcase
+        upload_query: {
+          key: encodedInfo['utf8.csv'].md5,
+          policy: '...',
+          'x-amz-algorithm': 'AWS4-HMAC-SHA256',
+          'x-amz-credential': 'XXX',
+          'x-amz-signature': 'YYY'
+        },
+        // eslint-disable-next-line camelcase
+        upload_url: rawstoreUrl
+      },
+      'datapackage.json': {
+        md5: encodedInfo['datapackage.json'].md5,
+        length: encodedInfo['datapackage.json'].length,
+        name: 'datapackage.json',
+        // eslint-disable-next-line camelcase
+        upload_query: {
+          key: encodedInfo['datapackage.json'].md5,
+          policy: '...',
+          'x-amz-algorithm': 'AWS4-HMAC-SHA256',
+          'x-amz-credential': 'XXX',
+          'x-amz-signature': 'YYY'
+        },
+        // eslint-disable-next-line camelcase
+        upload_url: rawstoreUrl
+      }
+    }
+  })
 
 const authorizeForServices = nock(config.api, {reqheaders: {'Auth-Token': 't35tt0k3N'}})
   .persist()
@@ -376,18 +473,99 @@ const apiSpecStore3 = nock(config.api, {
     errors: []
   })
 
+const apiSpecStoreEncoding = nock(config.api, {
+  reqheaders: {
+    'Auth-Token': 'authz.token'
+  }
+})
+  .persist()
+  .post('/source/upload', {
+    "meta":{
+      "version":1,
+      "ownerid":"test-userid",
+      "owner":"test-username",
+      "dataset":"iso",
+      "findability":"unlisted"
+    },
+    "inputs":[
+      {
+        "kind":"datapackage",
+        "url":"https://s3-us-west-2.amazonaws.com/jT+FS1ETWeNoGP1leT/6dQ==",
+        "parameters":{
+          "resource-mapping":{
+            "western-macos-roman.csv":"https://s3-us-west-2.amazonaws.com/IQKcpyJFVG3AKDZ1XfpsFg==",
+            "iso8859.csv":"https://s3-us-west-2.amazonaws.com/9YPisX1dNWWwt6OshEm7hg==",
+            "utf8.csv":"https://s3-us-west-2.amazonaws.com/VEyDK+05c4GRdRA5cvcKVw=="
+          },
+          "descriptor":{
+            "name":"iso",
+            "resources":[
+              {
+                "name":"western-macos-roman",
+                "path":"western-macos-roman.csv",
+                "schema":{
+                  "fields":[
+                    {"name":"Country Name","type":"string"},
+                    {"name":"Country Code","type":"string"},
+                    {"name":"Year","type":"integer"},
+                    {"name":"Value","type":"integer"}
+                  ]
+                },"encoding":"windows-1252"
+              },
+              {
+                "name":"iso",
+                "path":"iso8859.csv",
+                "schema":{
+                  "fields":[
+                    {"name":"Country Name","type":"string"},
+                    {"name":"Country Code","type":"string"},
+                    {"name":"Year","type":"integer"},
+                    {"name":"Value","type":"integer"}
+                  ]
+                },"encoding":"ISO-8859-1"},
+              {
+                "name":"utf",
+                "path":"utf8.csv",
+                "schema":{
+                  "fields":[
+                    {"name":"Country Name","type":"string"},
+                    {"name":"Country Code","type":"string"},
+                    {"name":"Year","type":"integer"},
+                    {"name":"Value","type":"integer"}
+                  ]},"encoding":"UTF-8"}
+                ]
+              }
+            }
+          }
+        ]
+      }
+  )
+  .reply(200, {
+    success: true,
+    id: 'test',
+    errors: []
+  })
+
 const signurl = nock(config.api, {reqheaders: {'Auth-Token': 'authz.token'}})
   .persist()
   .get('/rawstore/presign?ownerid=test-userid&url=https://s3-us-west-2.amazonaws.com/m84YSonibUrw5Mg8QbCNHA==')
   .reply(200, {url: 'https://s3-us-west-2.amazonaws.com/m84YSonibUrw5Mg8QbCNHA=='})
-  .get('/rawstore/presign?ownerid=test-userid&url=https://s3-us-west-2.amazonaws.com/s6Ex9JHrfrGSkEF7Gin8jg==')
-  .reply(200, {url: 'https://s3-us-west-2.amazonaws.com/s6Ex9JHrfrGSkEF7Gin8jg=='})
+  .get('/rawstore/presign?ownerid=test-userid&url=https://s3-us-west-2.amazonaws.com/m0kbjn9IxjopdBZo8bk0AA==')
+  .reply(200, {url: 'https://s3-us-west-2.amazonaws.com/m0kbjn9IxjopdBZo8bk0AA=='})
   .get('/rawstore/presign?ownerid=test-userid&url=https://s3-us-west-2.amazonaws.com/zqYInZMy1fFndkTED3QUPQ==')
   .reply(200, {url: 'https://s3-us-west-2.amazonaws.com/zqYInZMy1fFndkTED3QUPQ=='})
   .get('/rawstore/presign?ownerid=test-userid&url=https://s3-us-west-2.amazonaws.com/iwWrmUOdQ2tuOPx8P5wU7w==')
   .reply(200, {url: 'https://s3-us-west-2.amazonaws.com/m84YSonibUrw5Mg8QbCNHA=='})
   .get('/rawstore/presign?ownerid=test-userid&url=https://s3-us-west-2.amazonaws.com/5BU6f/3L1GigyvQ4nEHoKA==')
   .reply(200, {url: 'https://s3-us-west-2.amazonaws.com/iwWrmUOdQ2tuOPx8P5wU7w=='})
+  .get('/rawstore/presign?ownerid=test-userid&url=https://s3-us-west-2.amazonaws.com/jT+FS1ETWeNoGP1leT/6dQ==')
+  .reply(200, {url: 'https://s3-us-west-2.amazonaws.com/jT+FS1ETWeNoGP1leT/6dQ=='})
+  .get('/rawstore/presign?ownerid=test-userid&url=https://s3-us-west-2.amazonaws.com/IQKcpyJFVG3AKDZ1XfpsFg==')
+  .reply(200, {url: 'https://s3-us-west-2.amazonaws.com/IQKcpyJFVG3AKDZ1XfpsFg=='})
+  .get('/rawstore/presign?ownerid=test-userid&url=https://s3-us-west-2.amazonaws.com/9YPisX1dNWWwt6OshEm7hg==')
+  .reply(200, {url: 'https://s3-us-west-2.amazonaws.com/9YPisX1dNWWwt6OshEm7hg=='})
+  .get('/rawstore/presign?ownerid=test-userid&url=https://s3-us-west-2.amazonaws.com/VEyDK+05c4GRdRA5cvcKVw==')
+  .reply(200, {url: 'https://s3-us-west-2.amazonaws.com/VEyDK+05c4GRdRA5cvcKVw=='})
 
 
 test('push works with packaged dataset', async t => {
@@ -402,6 +580,20 @@ test('push works with packaged dataset', async t => {
 
   // TODO: make sure we have not altered the dataset.resources object in any way
   t.is(dataset.resources.length, 0)
+})
+
+test('push works with different encodings', async t => {
+  const dataset = await Dataset.load('test/fixtures/dp-encodings')
+  const options = {findability: 'unlisted'}
+  await datahub.push(dataset, options)
+
+  t.is(rawstoreAuthorizeEncoding.isDone(), true)
+  t.is(rawstoreStorageMock.isDone(), true)
+  t.is(apiSpecStoreEncoding.isDone(), true)
+  t.is(authorizeForServices.isDone(), true)
+
+  // TODO: make sure we have not altered the dataset.resources object in any way
+  t.is(dataset.resources.length, 3)
 })
 
 test('push-flow works', async t => {


### PR DESCRIPTION
Guess local file encodings and update descriptor with `encoding: XXX`

* We're using "data.js" library here to guess encodings.
* previous tests updated as encoding object is added to each dp.json
* includes New fixtures and test

refs - fixes https://github.com/datahq/data-cli/issues/154 and https://github.com/datahq/datahub-qa/issues/77

here is the datasets with resources that had a different kind of encodings when pushed. See on  datahub https://datahub.io/zelima/iso