### PR TITLE
Validate command improvements

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -4,16 +4,15 @@ const {Table} = require('tableschema')
 
 const {File, isUrl} = require('data.js')
 
-async function validate(descriptor, basePath) {
+async function validate(datasetObj) {
   try {
-    await validateMetadata(descriptor)
-    for (let i = 0; i < descriptor.resources.length; i++) {
-      // TODO what if resource is remote
-      const resource = File.load(descriptor.resources[i], {basePath})
-      if (resource.descriptor.format === 'csv') {
+    await validateMetadata(datasetObj.descriptor)
+    for (let i = 0; i < datasetObj.resources.length; i++) {
+      if (datasetObj.resources[i].descriptor.format === 'csv') {
         await validateData(
-          resource.descriptor.schema,
-          resource.path
+          datasetObj.resources[i].descriptor.schema,
+          datasetObj.resources[i].path,
+          datasetObj.resources[i].descriptor.dialect
         )
       }
     }
@@ -23,9 +22,13 @@ async function validate(descriptor, basePath) {
   }
 }
 
-async function validateData(schema, absPath) {
+async function validateData(schema, absPath, parserOptions) {
   // TODO: handle inlined data resources
-  const table = await Table.load(absPath, {schema})
+  let options = {schema}
+  if (parserOptions) {
+    Object.assign(options, parserOptions)
+  }
+  const table = await Table.load(absPath, options)
   await table.read()
   return true
 }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -8,7 +8,8 @@ async function validate(datasetObj) {
   try {
     await validateMetadata(datasetObj.descriptor)
     for (let i = 0; i < datasetObj.resources.length; i++) {
-      if (datasetObj.resources[i].descriptor.format === 'csv') {
+      // Run data validation against schema if file format is either csv or tsv:
+      if (['csv', 'tsv'].includes(datasetObj.resources[i].descriptor.format)) {
         await validateData(
           datasetObj.resources[i].descriptor.schema,
           datasetObj.resources[i].path,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datahub-client",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "APIs for interacting with DataHub",
   "main": "index.js",
   "scripts": {

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const test = require('ava')
 const nock = require('nock')
+const {Dataset} = require('data.js')
 
 const {validate, validateMetadata, validateData, Profile} = require('../lib/validate')
 
@@ -26,27 +27,27 @@ test('validate function', async t => {
       }
     ]
   }
-  const valid = await validate(descriptor)
+  let dataset = await Dataset.load(descriptor)
+  const valid = await validate(dataset)
   t.true(valid)
 
   const invalidDescriptor = {
     resources: []
   }
-  const invalid = await validate(invalidDescriptor)
+  dataset = await Dataset.load(invalidDescriptor)
+  const invalid = await validate(dataset)
   t.true(invalid[0].toString().includes('Array is too short (0), minimum 1'))
 })
 
 test('validate function with resource', async t => {
-  const basePath = path.join(__dirname, './fixtures/finance-vix/')
-  const descriptor = require(path.join(basePath, 'datapackage.json'))
-  const out = await validate(descriptor, basePath)
+  const dataset = await Dataset.load('test/fixtures/finance-vix/')
+  const out = await validate(dataset)
   t.true(out)
 })
 
 test('validate function with invalid resource', async t => {
-  const basePath = path.join(__dirname, './fixtures/invalid-finance-vix/')
-  const descriptor = require(path.join(basePath, 'datapackage.json'))
-  const out = await validate(descriptor, basePath)
+  const dataset = await Dataset.load('test/fixtures/invalid-finance-vix/')
+  const out = await validate(dataset)
   t.is(out.errors[0].message, 'The value "17.96" in column "VIXOpen" is not type "date" and format "default"')
 })
 


### PR DESCRIPTION
refactored 'validate' function to take dataset object (data.js) - refs https://github.com/datahq/data-cli/issues/270

- also refactored 'validateData' function to accept parser options so we can pass 'dialect' to it
- refactored tests
- publishing this changes to NPM as 0.2.5