### PR TITLE
Refactored error throwing logic

### DIFF
--- a/lib/utils/datahub.js
+++ b/lib/utils/datahub.js
@@ -117,7 +117,7 @@ class DataHub extends EventEmitter {
         throw new Error(out.errors.join('\n'))
       }
     }
-    throw new Error(responseError(res))
+    throw await responseError(res)
   }
 
   async pushFlow(specPath, dpJsonPath = '.datahub/datapackage.json'){
@@ -195,7 +195,7 @@ class DataHub extends EventEmitter {
         token, {method: 'GET'}
     )
     if (signedRes.status !== 200) {
-      throw new Error(responseError(signedRes))
+      throw await responseError(signedRes)
     }
     const dpSignedurl = await signedRes.json()
 
@@ -215,7 +215,7 @@ class DataHub extends EventEmitter {
       this._debugMsg(out)
       return out
     }
-    throw new Error(responseError(res))
+    throw await responseError(res)
   }
 
   async rawstoreAuthorize(resources, options={}) {
@@ -250,7 +250,7 @@ class DataHub extends EventEmitter {
       const out = await res.json()
       return out.filedata
     }
-    throw new Error(await responseError(res))
+    throw await responseError(res)
   }
 
   async _authz(service) {
@@ -295,7 +295,7 @@ class DataHub extends EventEmitter {
             token, {method: 'GET'}
         )
         if (res.status !== 200) {
-          throw new Error(responseError(res))
+          throw await responseError(res)
         }
         const signedurl = await res.json()
         resourceMapping[resourceName] = signedurl.url
@@ -312,7 +312,7 @@ class DataHub extends EventEmitter {
         token, {method: 'GET'}
     )
     if (res.status !== 200) {
-      throw new Error(responseError(res))
+      throw await responseError(res)
     }
     const dpSignedurl = await res.json()
     return {
@@ -453,7 +453,8 @@ async function responseError(res) {
     message = (body.error || {}).message
     userError = true
   } else {
-    message = await res.text()
+    // This was causing error and crashing the process. Not sure what is the source..
+    // message = await res.text()
     userError = false
   }
 


### PR DESCRIPTION
We had experienced this non-readable error messages before: `> Error! [object Promise]`

It was happening because it was trying to instantiate Error object on another Error object:
```
throw new Error(responseError(res))
```
where `responseError(res)` already an Error object.

Now, the code looks like following:
```
throw await responseError(res)
```
using `await` because responseError function returns promise.