### PR TITLE
[push][s] throw an error, when the resource.path is not secure.

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -47,9 +47,11 @@ async function validateMetadata(descriptor) {
   // https://github.com/datahq/data-cli/issues/265
   descriptor.resources.map(res => {
     if (res.path.includes('../') || res.path.startsWith('/')){
-      console.error("'/' Absolute path and '../' relative parent path are not allowed.\n" +
+      throw new Error(
+        res.path + '\n' +
+        "Absolute path (if starts from '/') and relative parent path (if includes '../')\n" +
+        "are prohibited due to security reasons.\n" +
         'https://frictionlessdata.io/specs/data-resource/#data-location')
-      throw new Error(res.path)
     }
   })
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -41,6 +41,18 @@ async function validateMetadata(descriptor) {
 
   const profile = await Profile.load(defaultProfile)
 
+  // TODO: remove this temporal fix, when
+  // TODO: https://github.com/frictionlessdata/tableschema-js/issues/133 is resolved
+  // datahub.io remote site Fails if there is  '../'  in the resource.path
+  // https://github.com/datahq/data-cli/issues/265
+  descriptor.resources.map(res => {
+    if (res.path.includes('../') || res.path.startsWith('/')){
+      console.error("'/' Absolute path and '../' relative parent path are not allowed.\n" +
+        'https://frictionlessdata.io/specs/data-resource/#data-location')
+      throw new Error(res.path)
+    }
+  })
+
   // Validate descriptor
   return profile.validate(descriptor)
 }

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -100,6 +100,29 @@ test('it returns list of errors if descriptor is invalid', async t => {
   t.true(error[0].toString().includes('Array is too short (0), minimum 1'))
 })
 
+test('validateMetadata does not allow insecure absolute resource.path ', async t =>{
+  const descriptor = {
+    name: 'invalid-descriptor',
+    resources: [
+      {name: 'valid', path: 'path'},
+      {name: 'invalid', path: '/root_path'},
+    ]
+  }
+  const error = await t.throws(validateMetadata(descriptor))
+  t.true(error.toString().includes('secur'))  // not secure; insecure; security reasons, etc
+})
+
+test('validateMetadata does not allow insecure parent relative resource.path', async t =>{
+  const descriptor = {
+    name: 'invalid-descriptor',
+    resources: [
+      {name: 'valid', path: 'path'},
+      {name: 'invalid', path: '../path'},
+    ]
+  }
+  const error = await t.throws(validateMetadata(descriptor))
+  t.true(error.toString().includes('secur'))  // not secure; insecure; security reasons, etc
+})
 // ====================================
 // Profile class
 // ====================================


### PR DESCRIPTION
https://github.com/datahq/data-cli/issues/265
https://github.com/frictionlessdata/tableschema-js/issues/133

Now, when user try to push a insecure descriptor - this will cause an error.