### PR TITLE
Allow profile to be the unique identifier from Data Package Schema Registry

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -53,12 +53,12 @@ class Profile {
     if (!jsonschema) {
       let knownProfiles = []
       try {
-        const profilesRes = await fetch('https://frictionlessdata.io/schemas/registry.json')
-        knownProfiles = await profilesRes.json()
+        const profilesResponse = await fetch('https://frictionlessdata.io/schemas/registry.json')
+        knownProfiles = await profilesResponse.json()
       } catch (err) {
         throw new Error('Failed to load schema registry')
       }
-      const remoteProfile = knownProfiles.find(prof => profile === prof.id)
+      const remoteProfile = knownProfiles.find(item => profile === item.id)
       if (remoteProfile) {
         try {
           const response = await fetch(remoteProfile.schema)

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -37,7 +37,7 @@ async function validateData(schema, absPath, parserOptions) {
 async function validateMetadata(descriptor) {
   // If descriptor has a profile property then use it
   // Else use the latest schema
-  const defaultProfile = descriptor.profile || 'https://frictionlessdata.io/schemas/data-package.json'
+  const defaultProfile = descriptor.profile || 'data-package'
 
   const profile = await Profile.load(defaultProfile)
 
@@ -51,24 +51,39 @@ class Profile {
   static async load(profile) {
     let jsonschema = _cache[profile]
     if (!jsonschema) {
-      // Remote
-      if (isUrl(profile)) {
+      let knownProfiles = []
+      try {
+        const profilesRes = await fetch('https://frictionlessdata.io/schemas/registry.json')
+        knownProfiles = await profilesRes.json()
+      } catch (err) {
+        throw new Error('Failed to load schema registry')
+      }
+      const remoteProfile = knownProfiles.find(prof => profile === prof.id)
+      if (remoteProfile) {
+        try {
+          const response = await fetch(remoteProfile.schema)
+          jsonschema = await response.json()
+        } catch (err) {
+          throw new Error('Can not retrieve remote profile ' + profile)
+        }
+      } else if (isUrl(profile)) {
         try {
           const response = await fetch(profile)
           jsonschema = await response.json()
         } catch (err) {
           throw new Error('Can not retrieve remote profile ' + profile)
         }
-
-      // Local
       } else {
         try {
+          // Local
           const schemaPath = './schema/' + profile + '.json'
           jsonschema = require(schemaPath)
         } catch (err) {
           throw new Error('Profiles registry hasn\'t profile ' + profile)
         }
       }
+
+
 
       _cache[profile] = jsonschema
     }

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -115,7 +115,7 @@ const PROFILES = [
 PROFILES.forEach(name => {
   test(`Profile.load method for ${name}`, async t => {
     const jsonschema = require(`./fixtures/schema/${name}.json`)
-    const defaultProfile = 'https://frictionlessdata.io/schemas/data-package.json'
+    const defaultProfile = name
     const profile = await Profile.load(defaultProfile)
     t.deepEqual(profile.jsonschema, jsonschema)
   })


### PR DESCRIPTION
Modify logic to load schemas for profile from Data Package Schema Registry -refs #24

After this PR user is able to set the profile property of descriptor according to spec https://frictionlessdata.io/specs/profiles/. In general profile from now on can be:
* not defined at all (is equivalent to setting `"profile": "data-package"`)
* id from the official [Data Package Schema Registry](https://frictionlessdata.io/schemas/registry.json)
* fully-qualified URL that points directly to a JSON Schema that can be used to validate the profile
* local path to the schema