### PR TITLE
Ability to push excel sheet by name

### DIFF
--- a/lib/utils/datahub.js
+++ b/lib/utils/datahub.js
@@ -378,10 +378,22 @@ async function getProcessingSteps(resources = [], sheets) {
         // We are using sheet idx starting from 1 so we need to add 1 to each idx:
         sheets = sheets.map(value => value + 1)
       } else if (sheets) { // When sheets are indexes of sheets separated by ','
-        sheets = sheets.split(',').map(value => parseInt(value))
-        sheets.forEach(sheet => {
-          if (workbook.SheetNames.length < sheet || !sheet) {
+        // Check if given sheet is an index or name:
+        sheets = sheets.split(',').map(value => {
+          if (!!parseInt(value)) {
+            return parseInt(value)
+          }
+          return value
+        })
+        // Check if sheet index is out of range or name doesn't exist:
+        // Convert sheet names to indexes because we have to pass index to tabulator:
+        sheets.forEach((sheet, idx) => {
+          if (sheet.constructor.name === 'Number' && workbook.SheetNames.length < sheet) {
             throw new Error(`sheet index ${sheet} is out of range: please, provide existing sheet index (sheet names are not accepted)`)
+          } else if (sheet.constructor.name === 'String' && !workbook.SheetNames.includes(sheet)) {
+            throw new Error(`sheet name ${sheet} does not exist in the given file.`)
+          } else if (sheet.constructor.name === 'String') {
+            sheets[idx] = workbook.SheetNames.indexOf(sheet) + 1
           }
         })
       } else { // Default case

--- a/test/utils.datahub.test.js
+++ b/test/utils.datahub.test.js
@@ -714,6 +714,9 @@ test('getProcessingSteps function works for Excel', async t => {
   processing = await getProcessingSteps(dataset.resources, '2')
   t.is(processing.length, 1)
   t.is(processing[0].output, 'sample-2sheets-sheet-2')
+  processing = await getProcessingSteps(dataset.resources, 'Sheet2')
+  t.is(processing[0].tabulator.sheet, 2)
+  t.is(processing[0].output, 'sample-2sheets-sheet-2')
 })
 
 test('getProcessingSteps function works for CSV with dialect', async t => {


### PR DESCRIPTION
Now publishers can push excel sheet by name. E.g.:

* `--sheets=secondSheet`
* `--sheets=1,secondSheet`
* `--sheets=1,2`
* `--sheets=1`
* `--sheets=all`