### PR TITLE
Dumpers are now accept 'sheet' option

### DIFF
--- a/lib/cat.js
+++ b/lib/cat.js
@@ -9,16 +9,21 @@ const XLSX = require('xlsx')
 
 const {stringToStream} = require('./utils/stream')
 
-const getRows = async (fileOrStream) => {
+const getRows = async (fileOrStream, {sheet}={}) => {
+  let rows
   if (fileOrStream.constructor.name === 'Socket') {
-    return await toArray(fileOrStream.pipe(parse()))
+    rows = await toArray(fileOrStream.pipe(parse()))
   } else {
-    return await toArray(await fileOrStream.rows())
+    rows = await toArray(await fileOrStream.rows({sheet}))
   }
+  if (!rows || rows.length === 0) {
+    throw new Error('Input source is empty or doesn\'t exist.\n> If you\'re using excel file, remember that sheet index starts from 1. You can also use a sheet name.')
+  }
+  return rows
 }
 
-const dumpAscii = async function (fileOrStream, {limit}={}) {
-  const rows = await getRows(fileOrStream)
+const dumpAscii = async function (fileOrStream, {limit, sheet}={}) {
+  const rows = await getRows(fileOrStream, {sheet})
 
   // Process.stdout.columns not defined when piping so we assume 100
   const termwidth = process.stdout.columns || 100
@@ -41,32 +46,32 @@ const dumpAscii = async function (fileOrStream, {limit}={}) {
   return stringToStream(table.toString())
 }
 
-const dumpCsv = async function (fileOrStream) {
+const dumpCsv = async function (fileOrStream, {sheet}={}) {
   const stringifier = CSV()
   let rows
   if (fileOrStream.constructor.name === 'Socket') {
     rows = fileOrStream.pipe(parse())
   } else {
-    rows = await fileOrStream.rows()
+    rows = await fileOrStream.rows({sheet})
   }
   return rows.pipe(stringifier)
 }
 
-const dumpMarkdown = async function (fileOrStream) {
-  const rows = await getRows(fileOrStream)
+const dumpMarkdown = async function (fileOrStream, {sheet}={}) {
+  const rows = await getRows(fileOrStream, {sheet})
   return stringToStream(mdTable(rows))
 }
 
-const dumpXlsx = async function (fileOrStream) {
-  const rows = await getRows(fileOrStream)
-  const sheet = XLSX.utils.aoa_to_sheet(rows)
-  const wb = {SheetNames: ['sheet'], Sheets: {sheet: sheet}}
+const dumpXlsx = async function (fileOrStream, {sheet}={}) {
+  const rows = await getRows(fileOrStream, {sheet})
+  const newSheet = XLSX.utils.aoa_to_sheet(rows)
+  const wb = {SheetNames: ['sheet'], Sheets: {sheet: newSheet}}
   const string = XLSX.write(wb, {type: 'buffer'})
   return stringToStream(string)
 }
 
-const dumpHtml = async function (fileOrStream) {
-  const rows = await getRows(fileOrStream)
+const dumpHtml = async function (fileOrStream, {sheet}={}) {
+  const rows = await getRows(fileOrStream, {sheet})
   let thead = `<thead>`
   rows[0].forEach(col => {
     thead += `\n<th>${col}</th>`


### PR DESCRIPTION
This PR enables data-cli tool's `cat` command to work with specified Excel sheet.