### PR TITLE
Don't do upload to AWS if a file already exists

### DIFF
--- a/lib/utils/datahub.js
+++ b/lib/utils/datahub.js
@@ -8,6 +8,7 @@ const XLSX = require('xlsx')
 const toArray = require('stream-to-array')
 const infer = require('tableschema').infer
 const YAML = require('yamljs')
+const urljoin = require('url-join')
 
 const {Agent} = require('./agent')
 
@@ -53,6 +54,13 @@ class DataHub extends EventEmitter {
     const uploads = resources.map(async resource => {
       // TODO: annoying that the serves parses the s3 url so we have to unparse it!
       const creds = rawstoreUploadCreds[resource.descriptor.path]
+      // Add the path to file in the rawstore - this is use by makeSourceSpec
+      // eslint-disable-next-line camelcase
+      creds.rawstore_url = urljoin(creds.upload_url, creds.upload_query.key)
+      // If a file already is on AWS then just skip uploading for it:
+      if (creds.exists) {
+        return
+      }
       const formData = new FormData()
       lodash.forEach(creds.upload_query, (v, k) => {
         formData.append(k, v)
@@ -84,10 +92,6 @@ class DataHub extends EventEmitter {
         const body = await res.text()
         throw new Error(`Error uploading to rawstore for ${resource.descriptor.path} with code ${res.status} reason ${body}`)
       }
-      // Finally add the path to file in the rawstore - this is use by makeSourceSpec
-      // TODO: should we use urljoin?
-      // eslint-disable-next-line camelcase
-      creds.rawstore_url = creds.upload_url + '/' + creds.upload_query.key
     })
     await Promise.all(uploads)
 


### PR DESCRIPTION
Simply skipping upload if `/rawstore/authorize` returns `"exists": true`.