### PR TITLE
Improved handling errors in validate module

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -11,26 +11,36 @@ async function validate(datasetObj) {
       // Run data validation against schema if file format is either csv or tsv:
       if (['csv', 'tsv'].includes(datasetObj.resources[i].descriptor.format)) {
         await validateData(
-          datasetObj.resources[i].descriptor.schema,
-          datasetObj.resources[i].path,
-          datasetObj.resources[i].descriptor.dialect
+          datasetObj.resources[i].descriptor,
+          datasetObj.resources[i].path
         )
       }
     }
     return true
   } catch (err) {
-    return err
+    // Throw error only if it is instance of Error:
+    if (err.constructor.name === 'Error') {
+      throw err
+    } else { // E.g., if it TableSchemaError then just return it so we treat it differently:
+      return err
+    }
   }
 }
 
-async function validateData(schema, absPath, parserOptions) {
+async function validateData(descriptor, absPath) {
   // TODO: handle inlined data resources
-  let options = {schema}
-  if (parserOptions) {
-    Object.assign(options, parserOptions)
+  let options = {schema: descriptor.schema}
+  if (descriptor.dialect) {
+    Object.assign(options, descriptor.dialect)
   }
   const table = await Table.load(absPath, options)
-  await table.read()
+  try {
+    await table.read()
+  } catch (err) {
+    err.resource = descriptor.name
+    err.path = absPath
+    throw err
+  }
   return true
 }
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "node-fetch": "^1.7.3",
     "opn": "^5.1.0",
     "progress": "^2.0.0",
-    "tableschema": "^1.4.2",
+    "tableschema": "^1.7.0",
     "tv4": "^1.3.0",
     "url-join": "^2.0.2",
     "xlsx": "^0.11.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datahub-client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "APIs for interacting with DataHub",
   "main": "index.js",
   "scripts": {

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -60,7 +60,7 @@ test('it validateData function works with valid schema and data', async t => {
   const dpjson = require(path.join(basePath, 'datapackage.json'))
   const descriptor = dpjson.resources[0]
   const path_ = path.join(basePath, descriptor.path)
-  const valid = await validateData(descriptor.schema, path_)
+  const valid = await validateData(descriptor, path_)
   t.true(valid)
 })
 
@@ -69,7 +69,7 @@ test('validateData fails if data is not valid against schema', async t => {
   const dpjson = require(path.join(basePath, 'datapackage.json'))
   const descriptor = dpjson.resources[0]
   const path_ = path.join(basePath, descriptor.path)
-  const error = await t.throws(validateData(descriptor.schema, path_))
+  const error = await t.throws(validateData(descriptor, path_))
   t.is(error.errors[0].message, 'The value "17.96" in column "VIXOpen" is not type "date" and format "default"')
   // t.true(error[0].toString().includes('Error: Wrong type for header: VIXOpen and value: 17.96'))
 })


### PR DESCRIPTION
`validate` function - throw an error if its constructor is `Error` but just return for other cases, e.g., for `TableSchemaError` so we can handle it differently than regular errors.

`valivadteData` function - include `resource` name and path in the `Error` object so we can easily print that information later.