### PR TITLE
[init] error message added in `data init` for invalid existing descriptor

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -151,7 +151,12 @@ class Init extends EventEmitter {
     ]
     const result = await inquirer.prompt(questions)
     if (result.answer === 'y') {
-      this.dpObj = await Dataset.load(this.path_)
+      try {
+        this.dpObj = await Dataset.load(this.path_)
+      } catch (err){
+        err.message += '\nExisting descriptor file is invalid, please fix or delete it manually.'
+        throw err
+      }
       const filesAndDirs = await this.scanOnlyDir()
       await this.shouldAddFiles(filesAndDirs.files, this.path_)
       await this.shouldScanDir(filesAndDirs.dirs, this.path_)

--- a/lib/init.js
+++ b/lib/init.js
@@ -154,7 +154,10 @@ class Init extends EventEmitter {
       try {
         this.dpObj = await Dataset.load(this.path_)
       } catch (err){
-        err.message += '\nExisting descriptor file is invalid, please fix or delete it manually.'
+        if (err.message.includes('Unexpected token')) {
+          // give a user some ideas what to do:
+          err.message += '\nExisting descriptor file is invalid, please fix or delete it manually.'
+        }
         throw err
       }
       const filesAndDirs = await this.scanOnlyDir()


### PR DESCRIPTION
#Issue: https://github.com/datahq/datahub-qa/issues/178

```shell
$ echo error > datapackage.json 
$ data init
> This process updates existing datapackage.json file.
> 
Press ^C at any time to quit.
? There is datapackage.json already. Do you want to update it - y/n? y
> Error! Unexpected token e in JSON at position
Existing descriptor file is invalid, please fix or delete it manually.
```